### PR TITLE
25 add additional logic to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ python run_omega.py \
 mode='train,val,test,predict' \
 trainer_params.max_epochs=200 \
 trainer_params.gpus=[0] \
-model_params.model_type="baseline" \
-dataset_params.dataset = 'cam4' \
+model_params.model_type="fcn" \
+dataset_params.dataset='cam4' \
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ dataset_params.dataset='cam4' \
 For default parameters consult `gaia.config.Config` class. There are three groups of parameters: `trainer_params, dataset_params, model_params` .
 
 Parameters can be specified by 
-- directly passing nested dictionaries for each or 
-- command line arcugemens using the `dot` notation
+- directly passing nested dictionaries for each
+- pass in nothing which will automatically read in defaults from Config
+- command line arcugemens using the `dot` notation to override specified Config defaults
 
 Example configs:
 

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -49,7 +49,6 @@ class Config():
         Get the CLI args to override defaults during runtime
         """       
         cli_args = OmegaConf.to_container(OmegaConf.from_cli())
-        print(type(cli_args))
         t = json.dumps(cli_args).translate(r'{}:\"\'')
         logger.info(f'CLI parameters: \n{t}')
         return cls(cli_args = cli_args)

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -18,7 +18,7 @@ class Config():
         Set default model parameters
         """
         # set general params (mode, seed, etc.)
-        self.mode = 'train,val'
+        self.mode = 'train,val,test,predict'
         self.seed = True
         self.interpolation_params = None
         

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -18,7 +18,7 @@ class Config():
         Set default model parameters
         """
         # set general params (mode, seed, etc.)
-        self.mode = 'train,val,test,predict'
+        self.mode = 'train,val,test'
         self.seed = True
         self.interpolation_params = None
         
@@ -78,26 +78,26 @@ class Config():
         base = dataset_paths[dataset]
         mean_thres_defaults = {"cam4": 1e-13, "spcam": 1e-15}
         var_index_file = base + "_var_index.pt"
-        batch_size_default = 24 * 96 * 144
+        batch_size = cli_args.get('dataset_params',{}).get("batch_size",24 * 96 * 144)
         
         dataset_params = dict(
             train=dict(
                 dataset_file=base + "_train.pt",
-                batch_size=batch_size_default,
+                batch_size=batch_size,
                 shuffle=True,
                 flatten=False,  # already flattened
                 var_index_file=var_index_file
             ),
             val=dict(
                 dataset_file=base + "_val.pt",
-                batch_size=batch_size_default,
+                batch_size=batch_size,
                 shuffle=False,
                 flatten=False,  # already flattened
                 var_index_file=var_index_file
             ),
             test=dict(
                 dataset_file=base+'_var_index.pt',
-                batch_size=batch_size_default,
+                batch_size=batch_size,
                 shuffle=False,
                 flatten=True,  # already flattened
                 var_index_file=var_index_file

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -1,141 +1,187 @@
 from omegaconf import OmegaConf, DictConfig
 from mergedeep import merge
+import sys
+import json
+import yaml
+from gaia import get_logger
+import re
+
+logger = get_logger(__name__)
 
 class Config():
     """
     Initialize config with default parameter
     then parse cli args and merge
     """
-    def __init__(self):
+    def __init__(self, cli_args=dict()):
         """
         Set default model parameters
         """
+        # set general params (mode, seed, etc.)
+        self.mode = 'train,val'
+        self.seed = True
+        self.interpolation_params = None
         
+        # set trainer params 
+        self.trainer_params = self.set_trainer_params(cli_args)
+        
+        # set dataset params
+        self.dataset_params = self.set_dataset_params(cli_args)
+        
+        # set model params
+        self.model_params = self.set_model_params(cli_args)
+                
+        # general config
+        self.config = dict(
+            mode = self.mode,
+            trainer_params = self.trainer_params,
+            dataset_params = self.dataset_params,
+            model_params = self.model_params,
+            seed = self.seed,
+            interpolation_params = self.interpolation_params,
+        )
+        logger.info(f"Config: \n{yaml.dump(self.config, indent=2)}")
+
+        
+    @classmethod
+    def readCLIargs(cls):
+        """
+        Get the CLI args to override defaults during runtime
+        """       
+        cli_args = OmegaConf.to_container(OmegaConf.from_cli())
+        print(type(cli_args))
+        t = json.dumps(cli_args).translate(r'{}:\"\'')
+        logger.info(f'CLI parameters: \n{t}')
+        return cls(cli_args = cli_args)
+    
+    @staticmethod
+    def set_trainer_params(cli_args=dict()):
+        """
+        Set trainer params
+        """
+        default_trainer_params = dict(
+            gpus=[1],
+            precision=16,
+            max_epochs=200
+        )
+        return merge(default_trainer_params, cli_args.get('trainer_params',{}))
+    
+    @staticmethod
+    def set_dataset_params(cli_args=dict()):
+        """
+        Set the dataset params
+        """
         dataset_paths = {
             "cam4": "/ssddg1/gaia/cam4/cam4-famip-30m-timestep_4",
             "spcam": "/ssddg1/gaia/spcam/spcamclbm-nx-16-20m-timestep_4",
         }
+        dataset = cli_args.get('dataset_params',{}).get('dataset', 'cam4')
+        base = dataset_paths[dataset]
         mean_thres_defaults = {"cam4": 1e-13, "spcam": 1e-15}
+        var_index_file = base + "_var_index.pt"
+        batch_size_default = 24 * 96 * 144
         
-        # general runtime parameters
-        self.mode = 'train,val'
-        self.dataset = 'cam4'
-        self.model_type = 'baseline'
-        self.seed = True
-        self.interpolation_params = None
-        
-        # default trainer parameters
-        self.trainer_params = dict(
-            gpus=[1],
-            precision=16,
-            max_epochs=250
-        )
-    
-        # default dataset parameters
-        self.dataset_params = dict(
+        dataset_params = dict(
             train=dict(
-                dataset_file=dataset_paths[self.dataset] + "_train.pt",
-                batch_size=24 * 96 * 144,
+                dataset_file=base + "_train.pt",
+                batch_size=batch_size_default,
                 shuffle=True,
                 flatten=False,  # already flattened
-                var_index_file=dataset_paths[self.dataset]+'_var_index.pt',
+                var_index_file=var_index_file
             ),
             val=dict(
-                dataset_file=dataset_paths[self.dataset] + "_val.pt",
-                batch_size=24 * 96 * 144,
+                dataset_file=base + "_val.pt",
+                batch_size=batch_size_default,
                 shuffle=False,
                 flatten=False,  # already flattened
-                var_index_file=dataset_paths[self.dataset]+'_var_index.pt',
+                var_index_file=var_index_file
             ),
             test=dict(
-                dataset_file=dataset_paths[self.dataset]+'_var_index.pt',
-                batch_size=24 * 96 * 144,
+                dataset_file=base+'_var_index.pt',
+                batch_size=batch_size_default,
                 shuffle=False,
                 flatten=True,  # already flattened
-                var_index_file=dataset_paths[self.dataset]+'_var_index.pt',
+                var_index_file=var_index_file
             ),
-            mean_thres=mean_thres_defaults[self.dataset]
+            mean_thres=mean_thres_defaults[dataset]
         )
-
-        # default model parameters
-        self.model_params = dict(
+        return merge(dataset_params, cli_args.get('dataset_params',{}))
+    
+    @staticmethod
+    def set_model_params(cli_args=dict()):
+        model_config = model_type_lookup(cli_args.get('model_params',{}).get('model_type', 'fcn'))
+        model_params = dict(
             memory_varaibles=None,      # can be ',' sep
             ignore_input_variables=None,# can be ',' sep
-            model_config = self.model_type_lookup(self.model_type),
+            model_config = model_config,
             lr=1e-3,
             use_output_scaling=False,
             replace_std_with_range=False,
             ckpt=None,
         )
-        
-        # general config
-        self.config = dict(
-            mode = self.mode,
-            dataset = self.dataset,
-            model_type = self.model_type,
-            seed = self.seed,
-            interpolation_params = self.interpolation_params,
-            trainer_params = self.trainer_params,
-            dataset_params = self.dataset_params,
-            model_params = self.model_params
-        )
-        
+        return merge(model_params, cli_args.get('model_params',{}))
+
+    
+def model_type_lookup(model_type):
+    """
+    Define the model_configs for various model_types
+    """
+    # you can change th
+    if model_type == "fcn":
+        model_config = {
+            "model_type": "fcn",
+            "num_layers": 7,
+            "hidden_size": 512,
+            "dropout": 0.01,
+            "leaky_relu": 0.15
+        }
+    elif model_type == "fcn_history":
+        model_config = {
+            "model_type": "fcn_history",
+            "num_layers": 7,
+            "hidden_size": 512,
+            "leaky_relu": 0.15
+        }
+
+    elif model_type == "conv1d":
+        model_config = {
+            "model_type": "conv1d",
+            "num_layers": 7,
+            "hidden_size": 128
+        }
+
+    elif model_type == "resdnn":
+        model_config = {
+            "model_type": "resdnn",
+            "num_layers": 7,
+            "hidden_size": 512,
+            "dropout": 0.01,
+            "leaky_relu": 0.15
+        }
+    elif model_type == "encoderdecoder":
+        model_config = {
+            "model_type": "encoderdecoder",
+            "num_layers": 7,
+            "hidden_size": 512,
+            "dropout": 0.01,
+            "leaky_relu": 0.15,
+            "bottleneck_dim": 32,
+        }
+    else:
+        raise ValueError
+    
+    return model_config
+
 
     def merge_cli_args(self):
         """
         Merge cli args with default parameters
         """
+        raise DeprecationWarning
+        print(OmegaConf.to_yaml(DictConfig(self.config)))
         cli_args = dict(OmegaConf.from_cli())
+        # model_config initialize here
         self.config = merge(self.config, cli_args)
-
+        print(OmegaConf.to_yaml(DictConfig(self.config)))
         
-    def model_type_lookup(self, model_type):
-        """
-        Define the model_configs for various model_types
-        """
-        
-        if model_type == "baseline":
-            model_config = {
-                "model_type": "fcn",
-                "num_layers": 7,
-                "hidden_size": 512,
-                "dropout": 0.01,
-                "leaky_relu": 0.15
-            }
-        elif model_type == "memory":
-            model_config = {
-                "model_type": "fcn_history",
-                "num_layers": 7,
-                "hidden_size": 512,
-                "leaky_relu": 0.15
-            }
-
-        elif model_type == "conv1d":
-            model_config = {
-                "model_type": "conv1d",
-                "num_layers": 7,
-                "hidden_size": 128
-            }
-
-        elif model_type == "resdnn":
-            model_config = {
-                "model_type": "resdnn",
-                "num_layers": 7,
-                "hidden_size": 512,
-                "dropout": 0.01,
-                "leaky_relu": 0.15
-            }
-        elif model_type == "encoderdecoder":
-            model_config = {
-                "model_type": "encoderdecoder",
-                "num_layers": 7,
-                "hidden_size": 512,
-                "dropout": 0.01,
-                "leaky_relu": 0.15,
-                "bottleneck_dim": 32,
-            }
-        else:
-            raise ValueError
-        
-        return model_config
     

--- a/gaia/training.py
+++ b/gaia/training.py
@@ -144,14 +144,13 @@ def make_pretty_for_log(d, max_char=100):
     )
 
 
-
 def main(
     mode="train",
-    trainer_params=Config().trainer_params,
-    dataset_params=Config().dataset_params,
-    model_params=Config().model_params,
-    seed=Config().seed,
-    interpolation_params = Config().interpolation_params
+    trainer_params=Config.set_trainer_params(),
+    dataset_params=Config.set_dataset_params(),
+    model_params=Config.set_model_params(),
+    seed=True,
+    interpolation_params = None
 ):
     if seed:
         logger.info("seeding everything")

--- a/run_omega.py
+++ b/run_omega.py
@@ -18,10 +18,9 @@ from gaia.plot import plot_results
 from gaia.config import Config
 
 if __name__ == "__main__":
-    config = Config()
-    config.merge_cli_args()
+    config = Config.readCLIargs()
     
-    main(mode = config.config['mode'],
+    main(mode=config.config['mode'],
          trainer_params=config.config['trainer_params'],
          dataset_params=config.config['dataset_params'],
          model_params=config.config['model_params'],


### PR DESCRIPTION
- main() keeps its original parameters so user can pass params explicitly
- otherwise, Config class reads in default params
- Issue with specifying a specific model_type or dataset is fixed
- dataset and model_type parameters are now configured under dataset_params.dataset and model_params.model_type, respectively 