### PR TITLE
add general_params to allow setting mode in cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To perform training, we use a machine with at least a single GPU and 64GBs of RA
 To run default training:
 ```bash
 python run_omega.py \
-mode='train,val,test,predict' \
+general_params.mode='train,val,test,predict' \
 trainer_params.max_epochs=200 \
 trainer_params.gpus=[0] \
 model_params.model_type="fcn" \
@@ -81,7 +81,7 @@ dataset_params.dataset='cam4' \
 
 ## Parameters
 
-For default parameters consult `gaia.config.Config` class. There are three groups of parameters: `trainer_params, dataset_params, model_params` .
+For default parameters consult `gaia.config.Config` class. There are four groups of parameters: `general_params, trainer_params, dataset_params, model_params` .
 
 Parameters can be specified by 
 - directly passing nested dictionaries for each
@@ -115,6 +115,9 @@ model_params =
 
 training_params = 
 {'precision': 16, 'max_epochs': 200, gpus=[0]}
+
+general_params = 
+{'mode': 'train,val,test', 'seed': True, 'interpolation_params': None}
 
 ```
 
@@ -189,6 +192,7 @@ To use a model saved under saved under `lightning_logs/version_XX` pass the chec
 
 ```shell
 python run_omega.py \
+general_params.mode=test \
 model_params.ckpt=lightning_logs/version_XX
 ```
 

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -31,12 +31,10 @@ class Config():
                 
         # general config
         self.config = dict(
-            mode = self.general_params['mode'],
+            general_params = self.general_params,
             trainer_params = self.trainer_params,
             dataset_params = self.dataset_params,
-            model_params = self.model_params,
-            seed = self.general_params['seed'],
-            interpolation_params = self.general_params['interpolation_params'],
+            model_params = self.model_params
         )
         logger.info(f"Config: \n{yaml.dump(self.config, indent=2)}")
 

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -13,21 +13,21 @@ class Config():
     Initialize config with default parameter
     then parse cli args and merge
     """
-    def __init__(self, cli_args=dict()):
+    def __init__(self, args=dict()):
         """
         Set default model parameters
         """
         # set general params (mode, seed, interpolation_params)    
-        self.general_params = self.set_general_params(cli_args)
+        self.general_params = self.set_general_params(args)
         
         # set trainer params 
-        self.trainer_params = self.set_trainer_params(cli_args)
+        self.trainer_params = self.set_trainer_params(args)
         
         # set dataset params
-        self.dataset_params = self.set_dataset_params(cli_args)
+        self.dataset_params = self.set_dataset_params(args)
         
         # set model params
-        self.model_params = self.set_model_params(cli_args)
+        self.model_params = self.set_model_params(args)
                 
         # general config
         self.config = dict(
@@ -48,6 +48,16 @@ class Config():
         t = json.dumps(cli_args).translate(r'{}:\"\'')
         logger.info(f'CLI parameters: \n{t}')
         return cls(cli_args = cli_args)
+    
+    @classmethod
+    def readList(cls, dotlist=[]):
+        """
+        Create the Config from a list if dot notation strings.
+        """
+        list_args = OmegaConf.to_container(OmegaConf.from_dotlist(dotlist))
+        t = json.dumps(list_args).translate(r'{}:\"\'')
+        logger.info(f'CLI parameters: \n{t}')
+        return cls(args = list_args)
     
     @staticmethod
     def set_general_params(cli_args=dict()):

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -17,10 +17,8 @@ class Config():
         """
         Set default model parameters
         """
-        # set general params (mode, seed, etc.)
-        self.mode = 'train,val,test'
-        self.seed = True
-        self.interpolation_params = None
+        # set general params (mode, seed, interpolation_params)    
+        self.general_params = self.set_general_params(cli_args)
         
         # set trainer params 
         self.trainer_params = self.set_trainer_params(cli_args)
@@ -33,12 +31,12 @@ class Config():
                 
         # general config
         self.config = dict(
-            mode = self.mode,
+            mode = self.general_params['mode'],
             trainer_params = self.trainer_params,
             dataset_params = self.dataset_params,
             model_params = self.model_params,
-            seed = self.seed,
-            interpolation_params = self.interpolation_params,
+            seed = self.general_params['seed'],
+            interpolation_params = self.general_params['interpolation_params'],
         )
         logger.info(f"Config: \n{yaml.dump(self.config, indent=2)}")
 
@@ -52,6 +50,19 @@ class Config():
         t = json.dumps(cli_args).translate(r'{}:\"\'')
         logger.info(f'CLI parameters: \n{t}')
         return cls(cli_args = cli_args)
+    
+    @staticmethod
+    def set_general_params(cli_args=dict()):
+        """
+        Set trainer params
+        """
+        default_general_params = dict(
+            mode='trian,val,test',
+            seed=True,
+            interpolation_params=None
+        )
+        return merge(default_general_params, cli_args.get('general_params',{}))
+
     
     @staticmethod
     def set_trainer_params(cli_args=dict()):

--- a/gaia/config.py
+++ b/gaia/config.py
@@ -44,10 +44,11 @@ class Config():
         """
         Get the CLI args to override defaults during runtime
         """       
+        # make it a regular dict() for handling
         cli_args = OmegaConf.to_container(OmegaConf.from_cli())
         t = json.dumps(cli_args).translate(r'{}:\"\'')
         logger.info(f'CLI parameters: \n{t}')
-        return cls(cli_args = cli_args)
+        return cls(args = cli_args)
     
     @classmethod
     def readList(cls, dotlist=[]):
@@ -115,7 +116,7 @@ class Config():
                 var_index_file=var_index_file
             ),
             test=dict(
-                dataset_file=base+'_var_index.pt',
+                dataset_file=base+'_test.pt',
                 batch_size=batch_size,
                 shuffle=False,
                 flatten=True,  # already flattened

--- a/gaia/training.py
+++ b/gaia/training.py
@@ -161,12 +161,12 @@ def make_pretty_for_log(d, max_char=100):
 
 
 def main(
-    mode="train",
+    mode=Config.set_general_params()['mode'],
     trainer_params=Config.set_trainer_params(),
     dataset_params=Config.set_dataset_params(),
     model_params=Config.set_model_params(),
-    seed=True,
-    interpolation_params = None
+    seed=Config.set_general_params()['seed'],
+    interpolation_params = Config.set_general_params()['interpolation_params']
 ):
     if seed:
         logger.info("seeding everything")

--- a/gaia/training.py
+++ b/gaia/training.py
@@ -308,6 +308,7 @@ def main(
             assert "ckpt" in model_params
             model_dir = model_params["ckpt"]
 
+        # model params loaded from checkpoint during test
         model = TrainingModel.load_from_checkpoint(get_checkpoint_file(model_dir))
 
         # model.model.scale = 16

--- a/run_omega.py
+++ b/run_omega.py
@@ -20,10 +20,10 @@ from gaia.config import Config
 if __name__ == "__main__":
     config = Config.readCLIargs()
     
-    main(mode=config.config['mode'],
+    main(mode=config.config['general_params']['mode'],
          trainer_params=config.config['trainer_params'],
          dataset_params=config.config['dataset_params'],
          model_params=config.config['model_params'],
-         seed=config.config['seed'],
-         interpolation_params=config.config['interpolation_params']
+         seed=config.config['general_params']['seed'],
+         interpolation_params=config.config['general_params']['interpolation_params']
          )


### PR DESCRIPTION
Add general_params in Config to encompass mode, seed, and interpolation_params. Previously there was a bug where these params would not be set when specified via CLI. 